### PR TITLE
fix(startup): resolve silent route-registration failures in IronPython

### DIFF
--- a/startup.py
+++ b/startup.py
@@ -1,84 +1,141 @@
 # startup.py - Lightweight coordinator
 
 from pyrevit import routes, script
-from pyrevit import DB
 import sys
 import os
 
+# ---- File logger for debugging (written to Documents/RevitMCP/) ----
+import traceback
+
+_log_dir = os.path.join(os.path.expanduser("~"), "Documents", "RevitMCP", "server_logs")
+_log_path = os.path.join(_log_dir, "pyrevit_startup.log")
+
+def _flog(msg):
+    try:
+        if not os.path.exists(_log_dir):
+            os.makedirs(_log_dir)
+        with open(_log_path, "a") as f:
+            f.write(msg + "\n")
+    except Exception:
+        pass
+
+_flog("=" * 60)
+_flog("RevitMCP startup.py executing...")
+
 logger = script.get_logger()
-logger.info("RevitMCP startup script executing...")
+if logger:
+    logger.info("RevitMCP startup script executing...")
 
 try:
     # Initialize API namespace
     api = routes.API("revit-mcp-v1")
-    logger.info("pyRevit routes API 'revit-mcp-v1' initialized.")
+    _flog("API 'revit-mcp-v1' created OK")
 
-    # Add extension directory to Python path
-    extension_dir = os.path.dirname(__file__)
-    lib_dir = os.path.join(extension_dir, 'lib')
-    routes_dir = os.path.join(lib_dir, 'routes')
-    
-    logger.info("Extension directory: {}".format(extension_dir))
-    logger.info("Lib directory: {}".format(lib_dir))
-    logger.info("Routes directory: {}".format(routes_dir))
-    logger.info("Routes directory exists: {}".format(os.path.exists(routes_dir)))
-    
-    if lib_dir not in sys.path:
-        sys.path.append(lib_dir)
-        logger.info("Added lib directory to Python path: {}".format(lib_dir))
-
-    # Import and register route modules
+    # Resolve extension directory safely (handles missing __file__ in IronPython)
     try:
-        logger.info("Attempting to import route modules...")
-        from routes import (
-            project_routes,
-            sheet_routes,
-            element_routes,
-            schema_routes
-        )
-        logger.info("Route modules imported successfully")
-        
-        # Register each module's routes
-        project_routes.register_routes(api)
-        logger.info("Project routes registered successfully")
-        
-        sheet_routes.register_routes(api)
-        logger.info("Sheet routes registered successfully")
-        
-        element_routes.register_routes(api)
-        logger.info("Element routes registered successfully")
+        _this_file = __file__
+        extension_dir = os.path.dirname(os.path.abspath(_this_file))
+    except NameError:
+        # __file__ not available - search known paths
+        _flog("__file__ not defined, searching known paths...")
+        _candidates = [
+            os.path.join(os.path.expanduser("~"), "AppData", "Roaming",
+                         "pyRevit", "Extensions", "RevitMCP.extension"),
+        ]
+        extension_dir = None
+        for _c in _candidates:
+            if os.path.exists(_c):
+                extension_dir = _c
+                break
+        if extension_dir is None:
+            raise RuntimeError("Cannot locate RevitMCP.extension directory")
 
-        schema_routes.register_routes(api)
-        logger.info("Schema routes registered successfully")
-        
-    except ImportError as ie:
-        logger.error("Error importing route modules: {}".format(ie), exc_info=True)
-        logger.info("Falling back to minimal routes...")
-        
-        # Minimal fallback - just project_info route for testing
-        @api.route('/project_info', methods=['GET'])
-        def handle_get_project_info_fallback(request):
-            route_logger = script.get_logger()
-            try:
-                current_uiapp = __revit__
-                if not hasattr(current_uiapp, 'ActiveUIDocument') or not current_uiapp.ActiveUIDocument:
-                    return routes.Response(status=503, data={"error": "No active UI document"})
-                doc = current_uiapp.ActiveUIDocument.Document
-                project_info = doc.ProjectInformation
-                return {
-                    "project_name": project_info.Name,
-                    "project_number": project_info.Number,
-                    "file_path": doc.PathName,
-                    "fallback_mode": True
-                }
-            except Exception as e:
-                return routes.Response(status=500, data={"error": str(e)})
-        
-        logger.info("Fallback route registered")
-        
-    logger.info("All route modules loaded successfully")
+    lib_dir    = os.path.join(extension_dir, "lib")
+    routes_dir = os.path.join(lib_dir, "routes")
+
+    _flog("extension_dir: {}".format(extension_dir))
+    _flog("lib_dir exists: {}".format(os.path.exists(lib_dir)))
+    _flog("routes_dir exists: {}".format(os.path.exists(routes_dir)))
+
+    if lib_dir not in sys.path:
+        sys.path.insert(0, lib_dir)
+        _flog("Added lib_dir to sys.path")
+
+    # ---- Register route modules one by one ----
+    registered = []
+    failed     = []
+
+    def _try_register(module_name, register_fn):
+        try:
+            register_fn(api)
+            registered.append(module_name)
+            _flog("  [OK] {}".format(module_name))
+        except Exception as _e:
+            failed.append(module_name)
+            _flog("  [FAIL] {}: {}".format(module_name, traceback.format_exc()))
+
+    try:
+        from routes import project_routes
+        _flog("Imported project_routes OK")
+        _try_register("project_routes", project_routes.register_routes)
+    except Exception as _e:
+        _flog("Import project_routes FAILED: {}".format(traceback.format_exc()))
+        failed.append("project_routes")
+
+    try:
+        from routes import sheet_routes
+        _flog("Imported sheet_routes OK")
+        _try_register("sheet_routes", sheet_routes.register_routes)
+    except Exception as _e:
+        _flog("Import sheet_routes FAILED: {}".format(traceback.format_exc()))
+        failed.append("sheet_routes")
+
+    try:
+        from routes import element_routes
+        _flog("Imported element_routes OK")
+        _try_register("element_routes", element_routes.register_routes)
+    except Exception as _e:
+        _flog("Import element_routes FAILED: {}".format(traceback.format_exc()))
+        failed.append("element_routes")
+
+    try:
+        from routes import schema_routes
+        _flog("Imported schema_routes OK")
+        _try_register("schema_routes", schema_routes.register_routes)
+    except Exception as _e:
+        _flog("Import schema_routes FAILED: {}".format(traceback.format_exc()))
+        failed.append("schema_routes")
+
+    _flog("Registered: {}".format(registered))
+    _flog("Failed:     {}".format(failed))
+
+    # ---- Minimal fallback if everything failed ----
+    if not registered:
+        _flog("All modules failed - registering fallback /project_info route")
+        try:
+            @api.route('/project_info', methods=['GET'])
+            def handle_get_project_info_fallback(request):
+                try:
+                    uiapp = __revit__
+                    doc = uiapp.ActiveUIDocument.Document
+                    pi = doc.ProjectInformation
+                    return {
+                        "project_name": pi.Name,
+                        "project_number": pi.Number,
+                        "file_path": doc.PathName,
+                        "fallback_mode": True
+                    }
+                except Exception as _ex:
+                    return routes.Response(status=500, data={"error": str(_ex)})
+            _flog("Fallback route /project_info registered OK")
+        except Exception as _fe:
+            _flog("Fallback route FAILED: {}".format(traceback.format_exc()))
 
 except Exception as e:
-    logger.error("Error during RevitMCP startup.py execution: {}".format(e), exc_info=True)
+    _flog("CRITICAL ERROR in startup.py: {}".format(traceback.format_exc()))
+    if logger:
+        logger.error("RevitMCP startup error: {}".format(e))
 
-logger.info("RevitMCP startup script finished.") 
+_flog("startup.py finished.")
+if logger:
+    logger.info("RevitMCP startup script finished.")


### PR DESCRIPTION
- Fix potential NameError when __file__ is not defined in pyRevit's IronPython execution context; fall back to a known-path search
- Remove unused top-level `from pyrevit import DB` import that could silently abort startup before any route is registered
- Register each route module independently so one failure doesn't prevent the others from loading
- Add granular file-based logging to ~/Documents/RevitMCP/server_logs/ pyrevit_startup.log for post-mortem debugging without needing pyRevit log access
- Add fallback /project_info route only when ALL modules fail, keeping the happy path unchanged